### PR TITLE
fix(seo): emit per-page title, description, canonical, OG/Twitter

### DIFF
--- a/components/SEOHead.tsx
+++ b/components/SEOHead.tsx
@@ -1,0 +1,86 @@
+import { Head } from "fresh/runtime";
+import { breadcrumbFromCanonical, head } from "../lib/head.ts";
+
+export function SEOHead() {
+  const h = head.value;
+
+  return (
+    <Head>
+      {/* Primary meta */}
+      <title>{h.title}</title>
+      <meta name="description" content={h.description} />
+      <link rel="canonical" href={h.canonical} />
+      <meta name="robots" content="index, follow" />
+
+      {/* Twitter Card — large summary with image */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@antonshubin" />
+      <meta name="twitter:title" content={h.title} />
+      <meta name="twitter:description" content={h.description} />
+      <meta name="twitter:image" content={h.ogImage} />
+
+      {/* Open Graph */}
+      <meta property="og:type" content={h.ogType} />
+      <meta property="og:title" content={h.title} />
+      <meta property="og:description" content={h.description} />
+      <meta property="og:url" content={h.canonical} />
+      <meta property="og:image" content={h.ogImage} />
+      <meta property="og:site_name" content="Anton Shubin" />
+      <meta property="og:locale" content="en_US" />
+
+      {/* JSON-LD Structured Data */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@graph": [
+              {
+                "@type": "Person",
+                "@id": "https://antonshubin.com/#person",
+                "name": "Anton Shubin",
+                "jobTitle": "Fractional CTO & Lead Architect",
+                "description":
+                  "I take non-technical founders from napkin sketch to production. Fixed-price milestones. Zero-bloat architecture. No dev-team drama.",
+                "url": "https://antonshubin.com",
+                "knowsAbout": [
+                  "Software Architecture",
+                  "SaaS Development",
+                  "Backend Engineering",
+                  "AI Integration",
+                  "Cloud Infrastructure",
+                  "Deno",
+                  "PostgreSQL",
+                  "System Design",
+                  "System Performance Optimization",
+                ],
+                "worksFor": {
+                  "@type": "Organization",
+                  "name": "NeatSoft PTE LTD",
+                  "url": "https://neatsoft.dev",
+                },
+              },
+              {
+                "@type": "WebSite",
+                "@id": "https://antonshubin.com/#website",
+                "url": "https://antonshubin.com",
+                "name": "Anton Shubin — Fractional CTO & Lead Architect",
+                "description": h.description,
+                "inLanguage": "en-US",
+                "publisher": { "@id": "https://antonshubin.com/#person" },
+              },
+              {
+                "@type": "BreadcrumbList",
+                "@id": `${h.canonical}#breadcrumb`,
+                "itemListElement": breadcrumbFromCanonical(
+                  h.canonical,
+                  h.title,
+                ),
+              },
+            ],
+          }),
+        }}
+      />
+    </Head>
+  );
+}

--- a/lib/head.ts
+++ b/lib/head.ts
@@ -1,0 +1,94 @@
+import { signal } from "@preact/signals";
+import { DOMAIN } from "./config.ts";
+
+export interface PageHead {
+  title: string;
+  description: string;
+  canonical: string;
+  ogImage: string;
+  ogType: "profile" | "article" | "website" | "service";
+  noindex?: boolean;
+}
+
+const DEFAULTS: PageHead = {
+  title: "Anton Shubin | Fractional CTO & SaaS Architect for Startups",
+  description:
+    "Fractional CTO and Lead Architect. I take your SaaS from napkin sketch to production — fixed-price milestones, zero-bloat architecture, no dev-team drama.",
+  canonical: "https://antonshubin.com/",
+  ogImage: "https://antonshubin.com/img/photo-big.webp",
+  ogType: "profile",
+};
+
+export const head = signal<PageHead>({ ...DEFAULTS });
+
+export function resetHead() {
+  head.value = { ...DEFAULTS };
+}
+
+// --------------- Breadcrumb helpers ---------------
+
+function humanize(slug: string): string {
+  return slug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Generate a BreadcrumbList itemListElement array from a canonical URL.
+ * Used by the JSON-LD structured data in _app.tsx.
+ */
+export function breadcrumbFromCanonical(
+  canonical: string,
+  pageName: string,
+) {
+  const path = canonical.replace(DOMAIN, "");
+  const segments = path.split("/").filter(Boolean);
+
+  const items: unknown[] = [
+    { "@type": "ListItem", position: 1, name: "Home", item: `${DOMAIN}/` },
+  ];
+
+  let acc = "";
+  segments.forEach((seg, idx) => {
+    acc += "/" + seg;
+    const isLast = idx === segments.length - 1;
+    items.push({
+      "@type": "ListItem",
+      position: idx + 2,
+      name: isLast ? pageName : humanize(seg),
+      item: `${DOMAIN}${acc}/`,
+    });
+  });
+
+  return items;
+}
+
+/**
+ * Generate a flat breadcrumb array for the visible <nav> in component/Breadcrumb.tsx.
+ * Returns [{ name, href? }, ...] where the last item has no href.
+ */
+export function getBreadcrumb(
+  canonical: string,
+  pageName: string,
+): { name: string; href?: string }[] {
+  const path = canonical.replace(DOMAIN, "");
+  const segments = path.split("/").filter(Boolean);
+
+  const items: { name: string; href?: string }[] = [{
+    name: "Home",
+    href: "/",
+  }];
+
+  let acc = "";
+  segments.forEach((seg, idx) => {
+    acc += "/" + seg;
+    const isLast = idx === segments.length - 1;
+    items.push({
+      name: isLast ? pageName : humanize(seg),
+      href: isLast ? undefined : acc + "/",
+    });
+  });
+
+  return items;
+}

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -1,21 +1,10 @@
 import { define } from "../lib/utils.ts";
 import { PLAUSIBLE_URL, UMAMI_ID, UMAMI_URL } from "../lib/config.ts";
 import SWUpdater from "../islands/SWUpdater.tsx";
+import { resetHead } from "../lib/head.ts";
 
-interface AppProps {
-  Component: preact.ComponentType;
-  title?: string;
-  description?: string;
-  url?: URL;
-  image?: string;
-  type?: string;
-}
-
-export default define.page(function App({ Component }: AppProps) {
-  const title = "Anton Shubin | Fractional CTO & SaaS Architect for Startups";
-  const description =
-    "Fractional CTO and Lead Architect. I take your SaaS from napkin sketch to production — fixed-price milestones, zero-bloat architecture, no dev-team drama.";
-  const canonical = "https://antonshubin.com/";
+export default define.page(function App({ Component }) {
+  resetHead();
 
   return (
     <html lang="en" class="h-full bg-slate-900">
@@ -25,45 +14,7 @@ export default define.page(function App({ Component }: AppProps) {
           name="viewport"
           content="width=device-width, initial-scale=1.0"
         />
-
-        {/* Primary meta */}
-        <title>{title}</title>
-        <meta name="description" content={description} />
         <meta name="theme-color" content="#0f172a" />
-        <link rel="canonical" href={canonical} />
-
-        {/* AI crawler meta — these are parsed by GPTBot, Google-Extended, etc. */}
-        <meta name="author" content="Anton Shubin" />
-        <meta
-          name="keywords"
-          content="Fractional CTO, Lead Architect, SaaS Development, Deno, TypeScript, MVP Development, Backend Architecture, AI Integration, Tech Consultant, Fixed-Price Development, Startup Technical Advisor, Non-Technical Founder, Napkin to Production"
-        />
-        <meta
-          name="robots"
-          content="index, follow, max-snippet:-1, max-image-preview:large"
-        />
-
-        {/* Twitter Card — large summary with image */}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:site" content="@antonshubin" />
-        <meta name="twitter:title" content={title} />
-        <meta name="twitter:description" content={description} />
-        <meta
-          name="twitter:image"
-          content="https://antonshubin.com/img/photo-big.webp"
-        />
-
-        {/* Open Graph */}
-        <meta property="og:type" content="profile" />
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={description} />
-        <meta property="og:url" content={canonical} />
-        <meta
-          property="og:image"
-          content="https://antonshubin.com/img/photo-big.webp"
-        />
-        <meta property="og:site_name" content="Anton Shubin" />
-        <meta property="og:locale" content="en_US" />
 
         {/* Minimal critical CSS to prevent FOUC while CSS loads */}
         <style>
@@ -93,87 +44,7 @@ export default define.page(function App({ Component }: AppProps) {
         <link rel="manifest" href="/manifest.json" />
         <meta name="mobile-web-app-capable" content="yes" />
 
-        {/* JSON-LD Structured Data — multiple schemas for AI crawlers */}
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@graph": [
-                {
-                  "@type": "Person",
-                  "@id": "https://antonshubin.com/#person",
-                  "name": "Anton Shubin",
-                  "jobTitle": "Fractional CTO & Lead Architect",
-                  "description":
-                    "I take non-technical founders from napkin sketch to production. Fixed-price milestones. Zero-bloat architecture. No dev-team drama.",
-                  "url": "https://antonshubin.com",
-                  "knowsAbout": [
-                    "Software Architecture",
-                    "SaaS Development",
-                    "Backend Engineering",
-                    "AI Integration",
-                    "Cloud Infrastructure",
-                    "Deno",
-                    "PostgreSQL",
-                    "System Design",
-                    "System Performance Optimization",
-                  ],
-                  "worksFor": {
-                    "@type": "Organization",
-                    "name": "NeatSoft PTE LTD",
-                    "url": "https://neatsoft.dev",
-                  },
-                },
-                {
-                  "@type": "WebSite",
-                  "@id": "https://antonshubin.com/#website",
-                  "url": "https://antonshubin.com",
-                  "name": "Anton Shubin — Fractional CTO & Lead Architect",
-                  "description": description,
-                  "inLanguage": "en-US",
-                  "publisher": { "@id": "https://antonshubin.com/#person" },
-                },
-                {
-                  "@type": "BreadcrumbList",
-                  "@id": "https://antonshubin.com/#breadcrumb",
-                  "itemListElement": [
-                    {
-                      "@type": "ListItem",
-                      "position": 1,
-                      "name": "Home",
-                      "item": "https://antonshubin.com",
-                    },
-                    {
-                      "@type": "ListItem",
-                      "position": 2,
-                      "name": "Catalog",
-                      "item": "https://antonshubin.com/catalog",
-                    },
-                    {
-                      "@type": "ListItem",
-                      "position": 3,
-                      "name": "How I Work",
-                      "item": "https://antonshubin.com/how-i-work",
-                    },
-                    {
-                      "@type": "ListItem",
-                      "position": 4,
-                      "name": "Blog",
-                      "item": "https://antonshubin.com/blog",
-                    },
-                    {
-                      "@type": "ListItem",
-                      "position": 5,
-                      "name": "Projects",
-                      "item": "https://antonshubin.com/projects",
-                    },
-                  ],
-                },
-              ],
-            }),
-          }}
-        />
+        {/* Analytics */}
         {PLAUSIBLE_URL && (
           <script defer data-domain="antonshubin.com" src={PLAUSIBLE_URL} />
         )}

--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -5,6 +5,8 @@ import { type BlogArticle, blogArticles, prettyDate } from "../../lib/data.ts";
 import { SCHEDULE_URL } from "../../lib/config.ts";
 import { marked } from "marked";
 import BlogImageEnhancer from "../../islands/BlogImageEnhancer.tsx";
+import { head } from "../../lib/head.ts";
+import { SEOHead } from "../../components/SEOHead.tsx";
 
 function getArticleBySlug(slug: string): BlogArticle | undefined {
   return blogArticles.find((a) => a.slug === slug);
@@ -76,8 +78,19 @@ export default define.page(function BlogArticle(ctx) {
     );
   }
 
+  head.value = {
+    ...head.value,
+    title: `${article.title} — Anton Shubin`,
+    description: article.description,
+    canonical: `https://antonshubin.com/blog/${article.slug}/`,
+    ogType: "article",
+    ogImage:
+      `https://antonshubin.com/img/blog/${article.slug}/${article.previewImageURL}`,
+  };
+
   return (
     <Layout currentPath="/blog">
+      <SEOHead />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -1,4 +1,6 @@
 import { define } from "../../lib/utils.ts";
+import { head } from "../../lib/head.ts";
+import { SEOHead } from "../../components/SEOHead.tsx";
 import { Layout } from "../../components/Layout.tsx";
 import { blogArticles, prettyDate } from "../../lib/data.ts";
 
@@ -23,6 +25,14 @@ const TAG_COLORS: Record<string, string> = {
 
 export default define.page(function Blog(ctx) {
   const tab = (ctx.url.searchParams.get("tab") || "all") as string;
+  head.value = {
+    ...head.value,
+    title: "Blog — Anton Shubin",
+    description:
+      "Technical articles, architecture deep-dives, and dev tips from a Fractional CTO.",
+    canonical: "https://antonshubin.com/blog/",
+    ogType: "website",
+  };
   const filtered = tab === "all"
     ? [...blogArticles].sort((a, b) => b.index - a.index)
     : blogArticles.filter((a) => a.category === tab).sort((a, b) =>
@@ -31,6 +41,7 @@ export default define.page(function Blog(ctx) {
 
   return (
     <Layout currentPath={ctx.url.pathname}>
+      <SEOHead />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white mb-2">Blog</h1>
         <p class="text-gray-400 mb-8 text-base sm:text-lg">

--- a/routes/catalog/[slug].tsx
+++ b/routes/catalog/[slug].tsx
@@ -3,6 +3,8 @@ import { Layout } from "../../components/Layout.tsx";
 import { SCHEDULE_URL } from "../../lib/config.ts";
 import { type CatalogItem, items } from "./index.tsx";
 import { marked } from "marked";
+import { head } from "../../lib/head.ts";
+import { SEOHead } from "../../components/SEOHead.tsx";
 
 export default define.page(function CatalogDetail(ctx) {
   const slug = ctx.params.slug;
@@ -34,8 +36,17 @@ export default define.page(function CatalogDetail(ctx) {
   const priceNum = parseFloat(item.price.replace(/[^0-9.]/g, ""));
   const priceCurrency = item.price.includes("$") ? "USD" : "USD";
 
+  head.value = {
+    ...head.value,
+    title: `${item.title} — Anton Shubin`,
+    description: item.desc,
+    canonical: `https://antonshubin.com/catalog/${item.slug}/`,
+    ogType: "website",
+  };
+
   return (
     <Layout currentPath="/catalog">
+      <SEOHead />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/routes/catalog/index.tsx
+++ b/routes/catalog/index.tsx
@@ -1,4 +1,6 @@
 import { define } from "../../lib/utils.ts";
+import { head } from "../../lib/head.ts";
+import { SEOHead } from "../../components/SEOHead.tsx";
 import { Layout } from "../../components/Layout.tsx";
 import { SCHEDULE_URL, UPWORK_URL } from "../../lib/config.ts";
 
@@ -312,8 +314,18 @@ export const items: CatalogItem[] = [
 ];
 
 export default define.page(function Catalog() {
+  head.value = {
+    ...head.value,
+    title: "Catalog — Anton Shubin",
+    description:
+      "Fixed-price SaaS development services, architecture audits, and fractional CTO consulting.",
+    canonical: "https://antonshubin.com/catalog/",
+    ogType: "website",
+  };
+
   return (
     <Layout currentPath="/catalog">
+      <SEOHead />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Project Catalog

--- a/routes/contact-me.tsx
+++ b/routes/contact-me.tsx
@@ -1,5 +1,7 @@
 import { define } from "../lib/utils.ts";
 import { Layout } from "../components/Layout.tsx";
+import { head } from "../lib/head.ts";
+import { SEOHead } from "../components/SEOHead.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
 import {
   CalendarIcon,
@@ -114,8 +116,17 @@ const contacts = [
 ];
 
 export default define.page(function ContactMe() {
+  head.value = {
+    ...head.value,
+    title: "Contact Anton Shubin",
+    description:
+      "Fractional CTO consultation, questions, and project inquiries.",
+    canonical: "https://antonshubin.com/contact-me/",
+    ogType: "website",
+  };
   return (
     <Layout currentPath="/contact-me">
+      <SEOHead />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Get in Touch

--- a/routes/how-i-work.tsx
+++ b/routes/how-i-work.tsx
@@ -1,5 +1,7 @@
 import type { ComponentChildren } from "preact";
 import { define } from "../lib/utils.ts";
+import { head } from "../lib/head.ts";
+import { SEOHead } from "../components/SEOHead.tsx";
 import { Layout } from "../components/Layout.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
 
@@ -109,8 +111,18 @@ const policies: PolicyItem[] = [
 ];
 
 export default define.page(function HowIWork() {
+  head.value = {
+    ...head.value,
+    title: "How I Deliver — Anton Shubin",
+    description:
+      "Zero micromanagement. Complete transparency. Predictable outcomes.",
+    canonical: "https://antonshubin.com/how-i-work/",
+    ogType: "website",
+  };
+
   return (
     <Layout currentPath="/how-i-work">
+      <SEOHead />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,4 +1,5 @@
 import { define } from "../lib/utils.ts";
+import { SEOHead } from "../components/SEOHead.tsx";
 import { Layout } from "../components/Layout.tsx";
 import { CTASection } from "../components/CTASection.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
@@ -17,6 +18,7 @@ import {
 export default define.page(function Home(ctx) {
   return (
     <Layout currentPath={ctx.url.pathname}>
+      <SEOHead />
       <div class="max-w-4xl mx-auto">
         {/* Hero Section */}
         <div class="mb-16 md:mb-24">

--- a/routes/infrastructure.tsx
+++ b/routes/infrastructure.tsx
@@ -1,5 +1,7 @@
 import { define } from "../lib/utils.ts";
 import { Layout } from "../components/Layout.tsx";
+import { head } from "../lib/head.ts";
+import { SEOHead } from "../components/SEOHead.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
 
 const services = [
@@ -44,8 +46,18 @@ const services = [
 ];
 
 export default define.page(function Infrastructure() {
+  head.value = {
+    ...head.value,
+    title: "Infrastructure & Architecture — Anton Shubin",
+    description:
+      "Self-hosted infrastructure stack powering 40+ services on a $50/mo budget.",
+    canonical: "https://antonshubin.com/infrastructure/",
+    ogType: "website",
+  };
+
   return (
     <Layout currentPath="/infrastructure">
+      <SEOHead />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Infrastructure Laboratory

--- a/routes/pay.tsx
+++ b/routes/pay.tsx
@@ -1,10 +1,21 @@
 import { define } from "../lib/utils.ts";
 import { Layout } from "../components/Layout.tsx";
+import { head } from "../lib/head.ts";
+import { SEOHead } from "../components/SEOHead.tsx";
 import CopyButton from "../islands/CopyButton.tsx";
 
 export default define.page(function Pay() {
+  head.value = {
+    ...head.value,
+    title: "Payment — Anton Shubin | Fractional CTO",
+    description: "Accepted payment methods: Stripe, SWIFT, BTC, ETH, Solana.",
+    canonical: "https://antonshubin.com/pay/",
+    ogType: "website",
+  };
+
   return (
     <Layout currentPath="/pay">
+      <SEOHead />
       <div class="max-w-5xl mx-auto px-4 py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Choose Your Payment Method

--- a/routes/projects/[slug].tsx
+++ b/routes/projects/[slug].tsx
@@ -3,6 +3,8 @@ import { Layout } from "../../components/Layout.tsx";
 import { type Project, projects } from "../../lib/data.ts";
 import { SCHEDULE_URL } from "../../lib/config.ts";
 import ImageGallery from "../../islands/ImageGallery.tsx";
+import { head } from "../../lib/head.ts";
+import { SEOHead } from "../../components/SEOHead.tsx";
 
 function getAllProjects(): Project[] {
   return [...projects.my, ...projects.freelance];
@@ -37,8 +39,20 @@ export default define.page(function ProjectDetail(ctx) {
 
   const isClientProject = projects.freelance.some((p) => p.slug === slug);
 
+  head.value = {
+    ...head.value,
+    title: `${project.title} — Anton Shubin`,
+    description: project.description,
+    canonical: `https://antonshubin.com/projects/${slug}/`,
+    ogType: "article",
+    ogImage: project.logoImageURL
+      ? `https://antonshubin.com${project.logoImageURL}`
+      : head.value.ogImage,
+  };
+
   return (
     <Layout currentPath="/projects">
+      <SEOHead />
       <div class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <a
           href="/projects"

--- a/routes/projects/index.tsx
+++ b/routes/projects/index.tsx
@@ -1,4 +1,6 @@
 import { define } from "../../lib/utils.ts";
+import { head } from "../../lib/head.ts";
+import { SEOHead } from "../../components/SEOHead.tsx";
 import { Layout } from "../../components/Layout.tsx";
 import { type Project, projects } from "../../lib/data.ts";
 import { ArchiveIcon } from "../../components/Icons.tsx";
@@ -110,6 +112,14 @@ function ProjectCard({
 
 export default define.page(function Projects(ctx) {
   const activeProjects = projects.my.filter((p) => !p.archived);
+  head.value = {
+    ...head.value,
+    title: "Projects — Anton Shubin",
+    description:
+      "Open-source projects, client work, and infrastructure portfolio by Anton Shubin.",
+    canonical: "https://antonshubin.com/projects/",
+    ogType: "website",
+  };
   const archivedProjects = projects.my.filter((p) => p.archived);
   const clientProjects = projects.freelance;
   const hasAny = activeProjects.length > 0 || archivedProjects.length > 0 ||
@@ -119,6 +129,7 @@ export default define.page(function Projects(ctx) {
     return (
       <Layout currentPath={ctx.url.pathname}>
         <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12 text-center">
+          <SEOHead />
           <h1 class="text-3xl font-bold text-white mb-4">Projects</h1>
           <p class="text-gray-400">No projects to display yet.</p>
         </div>
@@ -128,6 +139,7 @@ export default define.page(function Projects(ctx) {
 
   return (
     <Layout currentPath={ctx.url.pathname}>
+      <SEOHead />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white mb-2">
           Projects


### PR DESCRIPTION
Routes now set head.value via a shared signal. A new SEOHead component
using Freshs Head component injects per-page <title>, meta description,
canonical URL, OG/Twitter tags, and JSON-LD (Person, WebSite,
BreadcrumbList) into the document <head> on every request.

_key changes_
- lib/head.ts: signal store with PageHead interface, breadcrumb helpers
- components/SEOHead.tsx: reusable Fresh Head component
- routes/_app.tsx: stripped to static boilerplate only; calls resetHead()
- Every route: imports + sets head.value + includes <SEOHead />

Co-authored-by: openhands <openhands@all-hands.dev>
