### PR TITLE
fix(seo): noindex /pay, remove from sitemap, add X-Robots-Tag headers

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,0 +1,20 @@
+export async function handler(
+  req: Request,
+  ctx: { next: () => Promise<Response> },
+): Promise<Response> {
+  const url = new URL(req.url);
+  const pathname = url.pathname;
+
+  const res = await ctx.next();
+
+  if (pathname === "/pay" || pathname.startsWith("/pay/")) {
+    res.headers.set("X-Robots-Tag", "noindex, nofollow");
+  } else {
+    res.headers.set(
+      "X-Robots-Tag",
+      "index, follow, max-snippet:-1, max-image-preview:large",
+    );
+  }
+
+  return res;
+}

--- a/routes/sitemap.xml.ts
+++ b/routes/sitemap.xml.ts
@@ -45,12 +45,6 @@ export const handler = define.handlers({
         lastmod: undefined,
       },
       {
-        loc: "/pay",
-        priority: "0.5",
-        changefreq: "monthly",
-        lastmod: undefined,
-      },
-      {
         loc: "/infrastructure",
         priority: "0.7",
         changefreq: "monthly",


### PR DESCRIPTION
Pay was leaking into SERPs via the sitemap and meta robots. Root
middleware sets X-Robots-Tag for all routes (index with max-snippet
and max-image-preview). /pay route overrides with noindex, nofollow.

Co-authored-by: openhands <openhands@all-hands.dev>
