### PR TITLE
feat(seo): enrich Person schema and add Organization JSON-LD

### DIFF
--- a/components/SEOHead.tsx
+++ b/components/SEOHead.tsx
@@ -1,5 +1,6 @@
 import { Head } from "fresh/runtime";
 import { breadcrumbFromCanonical, head } from "../lib/head.ts";
+import { SAME_AS_URLS } from "../lib/config.ts";
 
 export function SEOHead() {
   const h = head.value;
@@ -39,10 +40,15 @@ export function SEOHead() {
                 "@type": "Person",
                 "@id": "https://antonshubin.com/#person",
                 "name": "Anton Shubin",
+                "givenName": "Anton",
+                "familyName": "Shubin",
                 "jobTitle": "Fractional CTO & Lead Architect",
                 "description":
                   "I take non-technical founders from napkin sketch to production. Fixed-price milestones. Zero-bloat architecture. No dev-team drama.",
                 "url": "https://antonshubin.com",
+                "image": "https://antonshubin.com/img/photo-big.webp",
+                "email": "mailto:hello@antonshubin.com",
+                "knowsLanguage": ["en", "ru"],
                 "knowsAbout": [
                   "Software Architecture",
                   "SaaS Development",
@@ -54,11 +60,25 @@ export function SEOHead() {
                   "System Design",
                   "System Performance Optimization",
                 ],
+                "award": [
+                  "Upwork Expert-Vetted",
+                  "Upwork 100% Job Success",
+                  "$395K+ earned on Upwork across 80+ projects",
+                ],
+                "sameAs": [...SAME_AS_URLS],
                 "worksFor": {
                   "@type": "Organization",
+                  "@id": "https://neatsoft.dev/#org",
                   "name": "NeatSoft PTE LTD",
                   "url": "https://neatsoft.dev",
                 },
+              },
+              {
+                "@type": "Organization",
+                "@id": "https://neatsoft.dev/#org",
+                "name": "NeatSoft PTE LTD",
+                "url": "https://neatsoft.dev",
+                "founder": { "@id": "https://antonshubin.com/#person" },
               },
               {
                 "@type": "WebSite",

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,3 +5,8 @@ export const UPWORK_URL = Deno.env.get("UPWORK_URL") ||
 export const PLAUSIBLE_URL = Deno.env.get("PLAUSIBLE_URL") || "";
 export const UMAMI_URL = Deno.env.get("UMAMI_URL") || "";
 export const UMAMI_ID = Deno.env.get("UMAMI_ID") || "";
+
+export const SAME_AS_URLS = [
+  "https://www.upwork.com/freelancers/ashubin",
+  "https://github.com/spy4x",
+] as const;

--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -103,9 +103,11 @@ export default define.page(function BlogArticle(ctx) {
             "timeRequired": `PT${article.readTime}M`,
             "author": {
               "@type": "Person",
+              "@id": "https://antonshubin.com/#person",
               "name": "Anton Shubin",
               "url": "https://antonshubin.com",
             },
+            "publisher": { "@id": "https://antonshubin.com/#person" },
           }),
         }}
       />


### PR DESCRIPTION
Person schema gains: image, sameAs (Upwork, GitHub), email,
knowsLanguage (en, ru), givenName, familyName, and award.
NeatSoft is now a standalone Organization block with a founder
link back to Person. BlogPosting author now uses @id reference
instead of inline object, plus publisher field.

Co-authored-by: openhands <openhands@all-hands.dev>
