### PR TITLE
feat(seo): add visible breadcrumb nav matching JSON-LD structure

### DIFF
--- a/components/Breadcrumb.tsx
+++ b/components/Breadcrumb.tsx
@@ -1,0 +1,39 @@
+interface Crumb {
+  name: string;
+  href?: string;
+}
+
+export function Breadcrumb({ items }: { items: Crumb[] }) {
+  if (items.length <= 1) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" class="mb-6 text-sm">
+      <ol class="flex flex-wrap items-center gap-1 text-gray-400">
+        {items.map((c, i) => (
+          <li class="flex items-center gap-1" key={i}>
+            {c.href && i < items.length - 1
+              ? (
+                <a
+                  href={c.href}
+                  class="hover:text-orange-400 transition-colors"
+                >
+                  {c.name}
+                </a>
+              )
+              : (
+                <span
+                  class="text-gray-500"
+                  aria-current={i === items.length - 1 ? "page" : undefined}
+                >
+                  {c.name}
+                </span>
+              )}
+            {i < items.length - 1 && (
+              <span aria-hidden="true" class="text-gray-600">/</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -5,8 +5,9 @@ import { type BlogArticle, blogArticles, prettyDate } from "../../lib/data.ts";
 import { SCHEDULE_URL } from "../../lib/config.ts";
 import { marked } from "marked";
 import BlogImageEnhancer from "../../islands/BlogImageEnhancer.tsx";
-import { head } from "../../lib/head.ts";
+import { getBreadcrumb, head } from "../../lib/head.ts";
 import { SEOHead } from "../../components/SEOHead.tsx";
+import { Breadcrumb } from "../../components/Breadcrumb.tsx";
 
 function getArticleBySlug(slug: string): BlogArticle | undefined {
   return blogArticles.find((a) => a.slug === slug);
@@ -91,6 +92,9 @@ export default define.page(function BlogArticle(ctx) {
   return (
     <Layout currentPath="/blog">
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -1,6 +1,7 @@
 import { define } from "../../lib/utils.ts";
-import { head } from "../../lib/head.ts";
+import { getBreadcrumb, head } from "../../lib/head.ts";
 import { SEOHead } from "../../components/SEOHead.tsx";
+import { Breadcrumb } from "../../components/Breadcrumb.tsx";
 import { Layout } from "../../components/Layout.tsx";
 import { blogArticles, prettyDate } from "../../lib/data.ts";
 
@@ -42,6 +43,9 @@ export default define.page(function Blog(ctx) {
   return (
     <Layout currentPath={ctx.url.pathname}>
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white mb-2">Blog</h1>
         <p class="text-gray-400 mb-8 text-base sm:text-lg">

--- a/routes/catalog/[slug].tsx
+++ b/routes/catalog/[slug].tsx
@@ -3,8 +3,9 @@ import { Layout } from "../../components/Layout.tsx";
 import { SCHEDULE_URL } from "../../lib/config.ts";
 import { type CatalogItem, items } from "./index.tsx";
 import { marked } from "marked";
-import { head } from "../../lib/head.ts";
+import { getBreadcrumb, head } from "../../lib/head.ts";
 import { SEOHead } from "../../components/SEOHead.tsx";
+import { Breadcrumb } from "../../components/Breadcrumb.tsx";
 
 export default define.page(function CatalogDetail(ctx) {
   const slug = ctx.params.slug;
@@ -46,6 +47,9 @@ export default define.page(function CatalogDetail(ctx) {
   return (
     <Layout currentPath="/catalog">
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/routes/catalog/index.tsx
+++ b/routes/catalog/index.tsx
@@ -1,6 +1,7 @@
 import { define } from "../../lib/utils.ts";
-import { head } from "../../lib/head.ts";
+import { getBreadcrumb, head } from "../../lib/head.ts";
 import { SEOHead } from "../../components/SEOHead.tsx";
+import { Breadcrumb } from "../../components/Breadcrumb.tsx";
 import { Layout } from "../../components/Layout.tsx";
 import { SCHEDULE_URL, UPWORK_URL } from "../../lib/config.ts";
 
@@ -326,6 +327,9 @@ export default define.page(function Catalog() {
   return (
     <Layout currentPath="/catalog">
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Project Catalog

--- a/routes/contact-me.tsx
+++ b/routes/contact-me.tsx
@@ -1,7 +1,8 @@
 import { define } from "../lib/utils.ts";
 import { Layout } from "../components/Layout.tsx";
-import { head } from "../lib/head.ts";
+import { getBreadcrumb, head } from "../lib/head.ts";
 import { SEOHead } from "../components/SEOHead.tsx";
+import { Breadcrumb } from "../components/Breadcrumb.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
 import {
   CalendarIcon,
@@ -127,6 +128,9 @@ export default define.page(function ContactMe() {
   return (
     <Layout currentPath="/contact-me">
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Get in Touch

--- a/routes/how-i-work.tsx
+++ b/routes/how-i-work.tsx
@@ -1,7 +1,8 @@
 import type { ComponentChildren } from "preact";
 import { define } from "../lib/utils.ts";
-import { head } from "../lib/head.ts";
+import { getBreadcrumb, head } from "../lib/head.ts";
 import { SEOHead } from "../components/SEOHead.tsx";
+import { Breadcrumb } from "../components/Breadcrumb.tsx";
 import { Layout } from "../components/Layout.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
 
@@ -123,6 +124,9 @@ export default define.page(function HowIWork() {
   return (
     <Layout currentPath="/how-i-work">
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/routes/infrastructure.tsx
+++ b/routes/infrastructure.tsx
@@ -1,7 +1,8 @@
 import { define } from "../lib/utils.ts";
 import { Layout } from "../components/Layout.tsx";
-import { head } from "../lib/head.ts";
+import { getBreadcrumb, head } from "../lib/head.ts";
 import { SEOHead } from "../components/SEOHead.tsx";
+import { Breadcrumb } from "../components/Breadcrumb.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
 
 const services = [
@@ -58,6 +59,9 @@ export default define.page(function Infrastructure() {
   return (
     <Layout currentPath="/infrastructure">
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Infrastructure Laboratory

--- a/routes/projects/[slug].tsx
+++ b/routes/projects/[slug].tsx
@@ -3,8 +3,9 @@ import { Layout } from "../../components/Layout.tsx";
 import { type Project, projects } from "../../lib/data.ts";
 import { SCHEDULE_URL } from "../../lib/config.ts";
 import ImageGallery from "../../islands/ImageGallery.tsx";
-import { head } from "../../lib/head.ts";
+import { getBreadcrumb, head } from "../../lib/head.ts";
 import { SEOHead } from "../../components/SEOHead.tsx";
+import { Breadcrumb } from "../../components/Breadcrumb.tsx";
 
 function getAllProjects(): Project[] {
   return [...projects.my, ...projects.freelance];
@@ -53,6 +54,9 @@ export default define.page(function ProjectDetail(ctx) {
   return (
     <Layout currentPath="/projects">
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <div class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <a
           href="/projects"

--- a/routes/projects/index.tsx
+++ b/routes/projects/index.tsx
@@ -1,6 +1,7 @@
 import { define } from "../../lib/utils.ts";
-import { head } from "../../lib/head.ts";
+import { getBreadcrumb, head } from "../../lib/head.ts";
 import { SEOHead } from "../../components/SEOHead.tsx";
+import { Breadcrumb } from "../../components/Breadcrumb.tsx";
 import { Layout } from "../../components/Layout.tsx";
 import { type Project, projects } from "../../lib/data.ts";
 import { ArchiveIcon } from "../../components/Icons.tsx";
@@ -130,6 +131,9 @@ export default define.page(function Projects(ctx) {
       <Layout currentPath={ctx.url.pathname}>
         <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12 text-center">
           <SEOHead />
+          <Breadcrumb
+            items={getBreadcrumb(head.value.canonical, head.value.title)}
+          />
           <h1 class="text-3xl font-bold text-white mb-4">Projects</h1>
           <p class="text-gray-400">No projects to display yet.</p>
         </div>
@@ -140,6 +144,9 @@ export default define.page(function Projects(ctx) {
   return (
     <Layout currentPath={ctx.url.pathname}>
       <SEOHead />
+      <Breadcrumb
+        items={getBreadcrumb(head.value.canonical, head.value.title)}
+      />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white mb-2">
           Projects


### PR DESCRIPTION
New Breadcrumb component renders a <nav aria-label="Breadcrumb"> with
aria-current="page" on the last item. Added to all content routes
(blog, catalog, projects detail+index, how-i-work, contact-me,
infrastructure). Homepage and /pay (noindex) are skipped.

Co-authored-by: openhands <openhands@all-hands.dev>
