### PR TITLE
fix(seo): use single-arg handler signature for Fresh middleware

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,9 +1,7 @@
 export async function handler(
-  req: Request,
-  ctx: { next: () => Promise<Response> },
+  ctx: { req: Request; url: URL; next: () => Promise<Response> },
 ): Promise<Response> {
-  const url = new URL(req.url);
-  const pathname = url.pathname;
+  const pathname = ctx.url.pathname;
 
   const res = await ctx.next();
 


### PR DESCRIPTION
Fresh 2.2 production build validates middleware handlers must have exactly one argument. The dev server (Vite) was lenient but production crashed with 'Handlers must only have one argument'.