### PR TITLE
fix(seo): set robots meta noindex for /pay via head signal

### DIFF
--- a/components/SEOHead.tsx
+++ b/components/SEOHead.tsx
@@ -11,7 +11,10 @@ export function SEOHead() {
       <title>{h.title}</title>
       <meta name="description" content={h.description} />
       <link rel="canonical" href={h.canonical} />
-      <meta name="robots" content="index, follow" />
+      <meta
+        name="robots"
+        content={h.noindex ? "noindex, nofollow" : "index, follow"}
+      />
 
       {/* Twitter Card — large summary with image */}
       <meta name="twitter:card" content="summary_large_image" />

--- a/routes/pay.tsx
+++ b/routes/pay.tsx
@@ -11,6 +11,7 @@ export default define.page(function Pay() {
     description: "Accepted payment methods: Stripe, SWIFT, BTC, ETH, Solana.",
     canonical: "https://antonshubin.com/pay/",
     ogType: "website",
+    noindex: true,
   };
 
   return (


### PR DESCRIPTION
CF edge overwrites X-Robots-Tag headers, so the middleware approach
was ineffective. Instead, SEOHead now checks head.value.noindex and
emits <meta name="robots" content="noindex, nofollow"> when set.

Co-authored-by: openhands <openhands@all-hands.dev>
