### PR TITLE
fix(seo): fix breadcrumb URL parsing, replace back buttons with breadcrumbs

### DIFF
--- a/lib/head.ts
+++ b/lib/head.ts
@@ -42,8 +42,7 @@ export function breadcrumbFromCanonical(
   canonical: string,
   pageName: string,
 ) {
-  const path = canonical.replace(DOMAIN, "");
-  const segments = path.split("/").filter(Boolean);
+  const segments = new URL(canonical).pathname.split("/").filter(Boolean);
 
   const items: unknown[] = [
     { "@type": "ListItem", position: 1, name: "Home", item: `${DOMAIN}/` },
@@ -67,13 +66,15 @@ export function breadcrumbFromCanonical(
 /**
  * Generate a flat breadcrumb array for the visible <nav> in component/Breadcrumb.tsx.
  * Returns [{ name, href? }, ...] where the last item has no href.
+ *
+ * Uses URL.pathname to strip protocol/domain/port/hash/query — immune to
+ * trailing-slash edge cases and DOMAIN env-var mismatches.
  */
 export function getBreadcrumb(
   canonical: string,
   pageName: string,
 ): { name: string; href?: string }[] {
-  const path = canonical.replace(DOMAIN, "");
-  const segments = path.split("/").filter(Boolean);
+  const segments = new URL(canonical).pathname.split("/").filter(Boolean);
 
   const items: { name: string; href?: string }[] = [{
     name: "Home",

--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -92,9 +92,6 @@ export default define.page(function BlogArticle(ctx) {
   return (
     <Layout currentPath="/blog">
       <SEOHead />
-      <Breadcrumb
-        items={getBreadcrumb(head.value.canonical, head.value.title)}
-      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -124,12 +121,9 @@ export default define.page(function BlogArticle(ctx) {
         }}
       />
       <article class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
-        <a
-          href="/blog"
-          class="inline-flex items-center gap-1 text-orange-400 hover:text-orange-300 transition-colors font-medium text-sm mb-8"
-        >
-          ← Back to blog
-        </a>
+        <Breadcrumb
+          items={getBreadcrumb(head.value.canonical, head.value.title)}
+        />
 
         <div class="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden">
           {/* Preview image */}

--- a/routes/catalog/[slug].tsx
+++ b/routes/catalog/[slug].tsx
@@ -47,9 +47,6 @@ export default define.page(function CatalogDetail(ctx) {
   return (
     <Layout currentPath="/catalog">
       <SEOHead />
-      <Breadcrumb
-        items={getBreadcrumb(head.value.canonical, head.value.title)}
-      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -108,12 +105,9 @@ export default define.page(function CatalogDetail(ctx) {
         }}
       />
       <div class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
-        <a
-          href="/catalog"
-          class="inline-flex items-center gap-1 text-orange-400 hover:text-orange-300 transition-colors font-medium text-sm mb-8"
-        >
-          ← Back to catalog
-        </a>
+        <Breadcrumb
+          items={getBreadcrumb(head.value.canonical, head.value.title)}
+        />
 
         <div class="bg-gray-800 rounded-xl border border-gray-700 p-3 sm:p-4 md:p-8">
           <div class="flex items-center gap-4 mb-6">

--- a/routes/projects/[slug].tsx
+++ b/routes/projects/[slug].tsx
@@ -54,16 +54,10 @@ export default define.page(function ProjectDetail(ctx) {
   return (
     <Layout currentPath="/projects">
       <SEOHead />
-      <Breadcrumb
-        items={getBreadcrumb(head.value.canonical, head.value.title)}
-      />
       <div class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
-        <a
-          href="/projects"
-          class="inline-flex items-center gap-1 text-orange-400 hover:text-orange-300 transition-colors font-medium text-sm mb-8"
-        >
-          ← Back to projects
-        </a>
+        <Breadcrumb
+          items={getBreadcrumb(head.value.canonical, head.value.title)}
+        />
 
         <div class="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden">
           {/* Header with logo */}

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 // Cache version — bump on each deploy where sw.js changes
-const CACHE = "antonshubin-v32";
+const CACHE = "antonshubin-v34";
 
 const PRECACHE_URLS = [
   "/",


### PR DESCRIPTION
getBreadcrumb and breadcrumbFromCanonical now use new URL().pathname
instead of canonical.replace(DOMAIN, "") — immune to trailing-slash
edge cases and DOMAIN env-var mismatches that caused "Https:" segments.

Back buttons ("← Back to blog/catalog/projects") replaced with the
Breadcrumb component on all three detail page types, placed at the
same location.

Co-authored-by: openhands <openhands@all-hands.dev>
