### PR TITLE
fix(seo): breadcrumb hrefs without trailing slashes, drop infra breadcrumb

### DIFF
--- a/lib/head.ts
+++ b/lib/head.ts
@@ -37,6 +37,10 @@ function humanize(slug: string): string {
 /**
  * Generate a BreadcrumbList itemListElement array from a canonical URL.
  * Used by the JSON-LD structured data in _app.tsx.
+ *
+ * Href values are WITHOUT trailing slashes (e.g. "/blog" not "/blog/").
+ * Fresh router handles both variants; the sitemap already omits them.
+ * The root "/" is the only exception (kept for correctness).
  */
 export function breadcrumbFromCanonical(
   canonical: string,
@@ -56,7 +60,7 @@ export function breadcrumbFromCanonical(
       "@type": "ListItem",
       position: idx + 2,
       name: isLast ? pageName : humanize(seg),
-      item: `${DOMAIN}${acc}/`,
+      item: `${DOMAIN}${acc}`,
     });
   });
 
@@ -69,6 +73,8 @@ export function breadcrumbFromCanonical(
  *
  * Uses URL.pathname to strip protocol/domain/port/hash/query — immune to
  * trailing-slash edge cases and DOMAIN env-var mismatches.
+ * Href values are WITHOUT trailing slashes (e.g. "/blog" not "/blog/"),
+ * matching the rest of the site. Only "/" keeps its slash.
  */
 export function getBreadcrumb(
   canonical: string,
@@ -87,7 +93,7 @@ export function getBreadcrumb(
     const isLast = idx === segments.length - 1;
     items.push({
       name: isLast ? pageName : humanize(seg),
-      href: isLast ? undefined : acc + "/",
+      href: isLast ? undefined : acc,
     });
   });
 

--- a/routes/infrastructure.tsx
+++ b/routes/infrastructure.tsx
@@ -1,8 +1,7 @@
 import { define } from "../lib/utils.ts";
 import { Layout } from "../components/Layout.tsx";
-import { getBreadcrumb, head } from "../lib/head.ts";
+import { head } from "../lib/head.ts";
 import { SEOHead } from "../components/SEOHead.tsx";
-import { Breadcrumb } from "../components/Breadcrumb.tsx";
 import { SCHEDULE_URL } from "../lib/config.ts";
 
 const services = [
@@ -59,9 +58,6 @@ export default define.page(function Infrastructure() {
   return (
     <Layout currentPath="/infrastructure">
       <SEOHead />
-      <Breadcrumb
-        items={getBreadcrumb(head.value.canonical, head.value.title)}
-      />
       <div class="max-w-4xl mx-auto px-2 sm:px-4 py-8 sm:py-12">
         <h1 class="text-3xl sm:text-4xl font-bold text-white text-center mb-2">
           Infrastructure Laboratory

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 // Cache version — bump on each deploy where sw.js changes
-const CACHE = "antonshubin-v34";
+const CACHE = "antonshubin-v35";
 
 const PRECACHE_URLS = [
   "/",


### PR DESCRIPTION
- breadcrumb hrefs now omit trailing slashes (e.g. "/blog" not "/blog/").
  Root "/" keeps its slash. Fresh router serves both variants.
- Infrastructure page no longer renders a breadcrumb (was just
  "Home / Infrastructure & Architecture", adds no navigation value).

Co-authored-by: openhands <openhands@all-hands.dev>
