### PR TITLE
fix(analytics): strip tracking scripts from bots, noindex staging, add GSC docs

### DIFF
--- a/docs/google-search-console.md
+++ b/docs/google-search-console.md
@@ -1,0 +1,30 @@
+# Google Search Console — Setup
+
+## Why
+
+Site gets zero Google organic traffic. `site:antonshubin.com` returns nothing.
+Without GSC, Google may not know the site exists at all.
+
+## Steps
+
+1. Go to https://search.google.com/search-console
+2. Add property: `antonshubin.com` (URL prefix, not domain)
+3. **DNS verification**: Add TXT record via DNS provider (likely Hetzner DNS):
+   - Name: `antonshubin.com`
+   - Type: `TXT`
+   - Value: `google-site-verification=...` (provided by GSC)
+4. After verification, submit sitemap:
+   - URL: `https://antonshubin.com/sitemap.xml`
+5. Request manual indexing: homepage, /how-i-work, /blog, /projects
+6. Check Coverage report weekly for errors
+
+## Also
+
+- Bing Webmaster Tools: https://www.bing.com/webmasters
+- After indexing, check Core Web Vitals report in GSC
+- Monitor Search Analytics tab for which queries drive impressions
+
+## Verification
+
+- `site:antonshubin.com` returns results within 1-2 weeks
+- Umami shows google.com referrer traffic

--- a/main.ts
+++ b/main.ts
@@ -29,6 +29,7 @@ app.use(async (ctx) => {
 
   // Staging: cache assets but NOT HTML (instant feedback on deploys)
   if (isStaging) {
+    resp.headers.set("X-Robots-Tag", "noindex, nofollow");
     if (isAsset(url)) {
       resp.headers.set(
         "Cache-Control",

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,10 +1,65 @@
+// Known AI crawlers, search bots, and social preview bots.
+// Kept in sync with robots.txt — these are welcome to crawl content
+// but we skip analytics scripts so they don't pollute stats.
+const BOT_UA_PATTERNS = [
+  // AI crawlers (explicitly allowed in robots.txt)
+  "GPTBot",
+  "Google-Extended",
+  "CCBot",
+  "anthropic-ai",
+  "ClaudeBot",
+  "Claude-API",
+  "PerplexityBot",
+  "Applebot-Extended",
+  "ChatGPT-User",
+  "OAI-SearchBot",
+  // Search engines
+  "Googlebot",
+  "Bingbot",
+  "YandexBot",
+  "Baiduspider",
+  "DuckDuckBot",
+  "Slurp",
+  "Yahoo! Slurp",
+  // Social preview
+  "Twitterbot",
+  "facebookexternalhit",
+  "LinkedInBot",
+  "Slack-LinkPreview",
+  "Discordbot",
+  "WhatsApp",
+  "TelegramBot",
+  "MetaInspector",
+  // Generic crawlers (careful — narrow patterns only)
+  "ia_archiver",
+  "PetalBot",
+  "DotBot",
+  "AdsBot",
+];
+
+const isBot = (req: Request): boolean => {
+  const ua = req.headers.get("user-agent") || "";
+  if (!ua) return false; // treat missing UA as client failure, not bot
+  return BOT_UA_PATTERNS.some((p) => ua.includes(p));
+};
+
 export async function handler(
   ctx: { req: Request; url: URL; next: () => Promise<Response> },
 ): Promise<Response> {
   const pathname = ctx.url.pathname;
+  const isCrawler = isBot(ctx.req);
+
+  // Only strip analytics for HTML page requests (not assets/API)
+  const isHtmlPage = !pathname.startsWith("/assets/") &&
+    !pathname.startsWith("/_fresh/") &&
+    !pathname.startsWith("/api/") &&
+    !pathname.startsWith("/img/") &&
+    !pathname.startsWith("/favicon") &&
+    pathname !== "/sw.js";
 
   const res = await ctx.next();
 
+  // ── X-Robots-Tag per path ────────────────────────────
   if (pathname === "/pay" || pathname.startsWith("/pay/")) {
     res.headers.set("X-Robots-Tag", "noindex, nofollow");
   } else {
@@ -12,6 +67,30 @@ export async function handler(
       "X-Robots-Tag",
       "index, follow, max-snippet:-1, max-image-preview:large",
     );
+  }
+
+  // ── Strip analytics scripts for known bots ────────────
+  // Prevents crawler pageviews from inflating Umami/Plausible stats.
+  // Without this, AI crawlers (which we welcome via robots.txt) execute
+  // JS and register as real "Chrome" visitors, skewing everything.
+  if (isCrawler && isHtmlPage) {
+    const body = await res.clone().text();
+    const clean = body
+      // Remove Umami tracker
+      .replace(
+        /<script\s+defer\s+src="[^"]*"\s+data-website-id="[^"]*"\s*><\/script>/gi,
+        "",
+      )
+      // Remove Plausible tracker
+      .replace(
+        /<script\s+defer\s+data-domain="[^"]*"\s+src="[^"]*"\s*><\/script>/gi,
+        "",
+      );
+    return new Response(clean, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
   }
 
   return res;


### PR DESCRIPTION
Known crawlers (AI, search, social preview) now get analytics-free HTML
so their pageviews don't inflate Umami/Plausible stats. The two bot
sessions that caused 54% of all events (149 + 66 pageviews) will no
longer register as 'Chrome' visitors.

Staging subdomain gets X-Robots-Tag: noindex to prevent duplicate content
penalties in search engines.

Adds GSC submission checklist for manual setup (zero Google traffic).

Fixes #49 - bot filtering middleware
Fixes #51 - noindex header for staging
Closes #50 - GSC submission checklist docs

Co-authored-by: openhands <openhands@all-hands.dev>
