### PR TITLE
feat(blog): add share buttons with UTM tracking to blog posts

### DIFF
--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -279,6 +279,67 @@ export default define.page(function BlogArticle(ctx) {
             </div>
           )}
 
+          {/* Share buttons */}
+          <div class="px-8 py-4 bg-gray-800 border-t border-gray-700">
+            <div class="flex flex-wrap items-center gap-3">
+              <span class="text-gray-500 text-sm font-medium">Share:</span>
+              <a
+                href={`https://twitter.com/intent/tweet?text=${
+                  encodeURIComponent(`"${article.title}" by @antonshubin`)
+                }&url=${
+                  encodeURIComponent(
+                    `https://antonshubin.com/blog/${article.slug}/?utm_source=twitter&utm_medium=social&utm_campaign=blog-share`,
+                  )
+                }`}
+                target="_blank"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm rounded-lg transition-colors"
+                aria-label="Share on Twitter"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                </svg>
+                Twitter
+              </a>
+              <a
+                href={`https://www.linkedin.com/sharing/share-offsite/?url=${
+                  encodeURIComponent(
+                    `https://antonshubin.com/blog/${article.slug}/?utm_source=linkedin&utm_medium=social&utm_campaign=blog-share`,
+                  )
+                }`}
+                target="_blank"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm rounded-lg transition-colors"
+                aria-label="Share on LinkedIn"
+              >
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                </svg>
+                LinkedIn
+              </a>
+              <a
+                href={`mailto:?subject=${
+                  encodeURIComponent(article.title)
+                }&body=${
+                  encodeURIComponent(
+                    `I thought you'd find this interesting:\n\n${article.title}\n\nhttps://antonshubin.com/blog/${article.slug}/?utm_source=email&utm_medium=social&utm_campaign=blog-share`,
+                  )
+                }`}
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm rounded-lg transition-colors"
+                aria-label="Share via email"
+              >
+                <svg
+                  class="w-4 h-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                Email
+              </a>
+            </div>
+          </div>
+
           {/* Footer CTA */}
           <div class="px-8 py-6 bg-gray-900/50 border-t border-gray-700">
             <div class="flex flex-wrap items-center justify-between gap-4">


### PR DESCRIPTION
Twitter/X, LinkedIn, and email share buttons with utm_source, utm_medium,
and utm_campaign parameters. Makes dark social visible in Umami analytics
and creates repeatable traffic source from social sharing.

Fixes #54

Co-authored-by: openhands <openhands@all-hands.dev>
