### PR TITLE
feat(blog): add related posts interlinking, strengthen homepage CTA

### DIFF
--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -27,6 +27,7 @@ interface PageData {
   content: string | null;
   prev: BlogArticle | null;
   next: BlogArticle | null;
+  related?: BlogArticle[];
 }
 
 export const handler = define.handlers({
@@ -40,6 +41,7 @@ export const handler = define.handlers({
         content: null,
         prev: null,
         next: null,
+        related: [],
       });
     }
 
@@ -53,12 +55,21 @@ export const handler = define.handlers({
     const body = markdown ? markdown.replace(/^---[\s\S]*?---\n*/, "") : null;
     const content = body ? await marked(body) : null;
 
-    return page<PageData>({ article, content, prev, next });
+    // Related posts: same category, exclude self, max 3
+    const related = article
+      ? blogArticles
+        .filter((a) =>
+          a.category && a.category === article.category && a.slug !== slug
+        )
+        .slice(0, 3)
+      : [];
+
+    return page<PageData>({ article, content, prev, next, related });
   },
 });
 
 export default define.page(function BlogArticle(ctx) {
-  const { article, content, prev, next } = ctx.data as PageData;
+  const { article, content, prev, next, related = [] } = ctx.data as PageData;
 
   if (!article) {
     return (
@@ -226,6 +237,33 @@ export default define.page(function BlogArticle(ctx) {
                 </p>
               )}
           </div>
+
+          {/* Related posts — same category interlinking */}
+          {related && related.length > 0 && (
+            <div class="px-4 pt-6 pb-4 bg-gray-800 border-t border-gray-700">
+              <h3 class="text-base font-semibold text-gray-400 mb-4">
+                Read next
+              </h3>
+              <div class="grid gap-3 sm:grid-cols-2">
+                {related.map((r) => (
+                  <a
+                    href={`/blog/${r.slug}`}
+                    class="block p-4 bg-gray-900/50 rounded-lg hover:bg-gray-900 transition-colors group"
+                  >
+                    <p class="text-white text-sm font-medium group-hover:text-orange-400 transition-colors leading-snug mb-1">
+                      {r.title}
+                    </p>
+                    <p class="text-gray-500 text-xs line-clamp-2">
+                      {r.description}
+                    </p>
+                    <p class="text-gray-600 text-xs mt-1.5">
+                      {r.readTime} min read
+                    </p>
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Previous / Next article navigation */}
           {(prev || next) && (

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -87,7 +87,19 @@ export default define.page(function Home(ctx) {
                 </a>
               </div>
 
-              <div class="mt-6 flex flex-wrap gap-2">
+              {/* Primary CTA — prominent gradient button */}
+              <div class="mt-6">
+                <a
+                  href={SCHEDULE_URL}
+                  target="_blank"
+                  class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-orange-600 to-amber-500 text-white font-semibold rounded-lg shadow-lg shadow-orange-500/25 hover:scale-105 hover:shadow-xl transition-all duration-200 text-base"
+                >
+                  <CalendarIcon class="w-5 h-5" />
+                  Book a free intro call — no pitch, just advice
+                </a>
+              </div>
+
+              <div class="mt-4 flex flex-wrap gap-2">
                 <a
                   href="https://github.com/spy4x"
                   target="_blank"
@@ -111,36 +123,6 @@ export default define.page(function Home(ctx) {
                   title="Upwork profile"
                 >
                   <UpworkIcon class="w-auto h-4 text-white" />
-                </a>
-              </div>
-              <div class="mt-4 flex flex-wrap gap-2">
-                <a
-                  href={SCHEDULE_URL}
-                  target="_blank"
-                  class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-500 transition-colors"
-                >
-                  <CalendarIcon class="w-4 h-4" />
-                  Schedule a call
-                </a>
-                <a
-                  href="/contact-me"
-                  class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md text-white bg-gray-600 hover:bg-gray-500 transition-colors"
-                >
-                  <svg
-                    class="w-4 h-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
-                    />
-                  </svg>
-                  Contact me
                 </a>
               </div>
             </div>


### PR DESCRIPTION
- Blog posts now show related articles (same category) for internal linking
- Homepage hero gets prominent gradient CTA above fold
  ('Book a free intro call — no pitch, just advice')
- Fixes #52 (homepage bounce rate), #53 (content interlinking)

Co-authored-by: openhands <openhands@all-hands.dev>
