### PR TITLE
fix(seo): resolve GSC indexing and rich result issues

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,17 @@ import type { State } from "./lib/utils.ts";
 
 export const app = new App<State>();
 
+// www → non-www redirect (301 permanent)
+app.use(async (ctx) => {
+  const hostname = ctx.url.hostname;
+  if (hostname.startsWith("www.")) {
+    const target = new URL(ctx.url);
+    target.hostname = hostname.slice(4);
+    return Response.redirect(target.toString(), 301);
+  }
+  return await ctx.next();
+});
+
 // Core static page routes that change infrequently (cached 3 days at edge).
 const CORE_PAGES = new Set([
   "/",

--- a/routes/catalog/[slug].tsx
+++ b/routes/catalog/[slug].tsx
@@ -52,17 +52,16 @@ export default define.page(function CatalogDetail(ctx) {
         dangerouslySetInnerHTML={{
           __html: JSON.stringify({
             "@context": "https://schema.org",
-            "@type": "Service",
-            "@id": `https://antonshubin.com/catalog/${item.slug}/#service`,
+            "@type": "Product",
+            "@id": `https://antonshubin.com/catalog/${item.slug}/#product`,
             "name": item.title,
             "description": item.desc,
-            "serviceType": "Fractional CTO & SaaS Architecture",
             "image": "https://antonshubin.com/img/photo-big.webp",
-            "provider": {
-              "@type": "Person",
-              "@id": "https://antonshubin.com/#person",
+            "brand": {
+              "@type": "Brand",
               "name": "Anton Shubin",
             },
+            "category": "Fractional CTO & SaaS Architecture",
             "areaServed": { "@type": "Place", "name": "Worldwide" },
             "aggregateRating": {
               "@type": "AggregateRating",

--- a/routes/sitemap.xml.ts
+++ b/routes/sitemap.xml.ts
@@ -78,10 +78,13 @@ export const handler = define.handlers({
     const catalogSlugs = [
       "strategy-call",
       "free-architecture-audit",
+      "technical-discovery-sprint",
       "zero-to-production-saas-mvp",
       "bulletproof-backend-api",
       "surgical-ai-integration",
       "codebase-health-audit",
+      "mcp-server-development",
+      "cto-advisory-retainer",
       "post-launch-support-maintenance",
     ];
     const catalogUrls = catalogSlugs.map((s) => ({


### PR DESCRIPTION
Change catalog schema from Service to Product — Google requires
Product type for 'Product snippets' and 'Merchant listings' rich
results. All existing fields (image, aggregateRating, review,
offers with returnPolicy + shippingDetails) preserved.

Add 3 missing catalog slugs to sitemap: technical-discovery-sprint,
mcp-server-development, cto-advisory-retainer.

Add www→non-www 301 redirect middleware to consolidate canonical.

Co-authored-by: openhands <openhands@all-hands.dev>
