### PR TITLE
fix(sw-updater): change Reload btn text to gray-900 for visibility

### DIFF
--- a/islands/SWUpdater.tsx
+++ b/islands/SWUpdater.tsx
@@ -52,7 +52,7 @@ export default function SWUpdater() {
       <button
         type="button"
         onClick={reload}
-        class="ml-auto sm:ml-0 cursor-pointer rounded bg-white px-3 py-1 text-sm font-semibold text-orange-600 hover:bg-orange-100"
+        class="ml-auto sm:ml-0 cursor-pointer rounded bg-white px-3 py-1 text-sm font-semibold text-gray-900 hover:bg-orange-100"
       >
         Reload
       </button>


### PR DESCRIPTION
Button text was white-on-white (text-orange-600 not resolving,
inheriting text-white from parent). Use text-gray-900 for guaranteed
contrast on white bg.

Co-authored-by: openhands <openhands@all-hands.dev>
