### PR TITLE
fix(catalog): correct merchant listing structured data types

### DIFF
--- a/routes/catalog/[slug].tsx
+++ b/routes/catalog/[slug].tsx
@@ -91,23 +91,28 @@ export default define.page(function CatalogDetail(ctx) {
                 "hasMerchantReturnPolicy": {
                   "@type": "MerchantReturnPolicy",
                   "applicableCountry": {
-                    "@type": "Place",
+                    "@type": "Country",
                     "name": "Worldwide",
                   },
                   "returnPolicyCategory":
                     "https://schema.org/MerchantReturnFiniteReturnWindow",
                   "merchantReturnDays": 14,
-                  "returnMethod": "https://schema.org.ReturnByMail",
-                  "returnFees": "https://schema.org.FreeReturn",
+                  "returnMethod": "https://schema.org/ReturnByMail",
+                  "returnFees": "https://schema.org/FreeReturn",
                   "returnPolicyCountry": {
-                    "@type": "Place",
+                    "@type": "Country",
                     "name": "Worldwide",
                   },
                 },
                 "shippingDetails": {
                   "@type": "OfferShippingDetail",
+                  "shippingRate": {
+                    "@type": "MonetaryAmount",
+                    "value": "0",
+                    "currency": "USD",
+                  },
                   "shippingDestination": {
-                    "@type": "Place",
+                    "@type": "DefinedRegion",
                     "name": "Worldwide",
                   },
                   "deliveryTime": {

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 // Cache version — bump on each deploy where sw.js changes
-const CACHE = "antonshubin-v55";
+const CACHE = "antonshubin-v57";
 
 const PRECACHE_URLS = [
   "/",


### PR DESCRIPTION
Fix 4 Schema.org validation errors found by Google Search Console:
- returnFees: use slash not dot in enum URL
- returnMethod: use slash not dot in enum URL
- applicableCountry/returnPolicyCountry: use Country not Place type
- shippingDetails: use DefinedRegion not Place for shippingDestination,
  add required shippingRate

Co-authored-by: openhands <openhands@all-hands.dev>
