### PR TITLE
fix(catalog): add scope breakdown to SaaS MVP card and exclusions

### DIFF
--- a/routes/catalog/[slug].tsx
+++ b/routes/catalog/[slug].tsx
@@ -244,6 +244,30 @@ export default define.page(function CatalogDetail(ctx) {
             </ul>
           </div>
 
+          {/* Not included (exclusions) */}
+          {item.exclusions && item.exclusions.length > 0 && (
+            <div class="mb-8">
+              <h2 class="text-lg font-semibold text-white mb-3 flex items-center gap-2">
+                <span class="text-gray-500">×</span> Not included
+              </h2>
+              <ul class="space-y-2">
+                {item.exclusions.map((exc, j) => (
+                  <li
+                    key={j}
+                    class="text-gray-500 flex items-start gap-2 text-sm"
+                  >
+                    <span class="text-gray-600 shrink-0 mt-0.5">×</span>
+                    {exc}
+                  </li>
+                ))}
+              </ul>
+              <p class="text-gray-500 text-xs mt-3 italic">
+                Need something not listed? Most items can be added as a
+                fixed-price milestone — get in touch for a custom quote.
+              </p>
+            </div>
+          )}
+
           {/* Tech stack */}
           <div class="mb-8">
             <h2 class="text-lg font-semibold text-white mb-3">Tech Stack</h2>

--- a/routes/catalog/index.tsx
+++ b/routes/catalog/index.tsx
@@ -14,6 +14,7 @@ export interface CatalogItem {
   desc: string;
   outcome: string;
   includes: string[];
+  exclusions?: string[];
   tech: string[];
   upworkUrl?: string;
   audience: string;
@@ -112,12 +113,20 @@ export const items: CatalogItem[] = [
     outcome:
       "A live, revenue-ready product in 21 days. Real users, real payments, real traction — without building an in-house team.",
     includes: [
-      "User authentication (email/social login)",
-      "Payment integration (Stripe)",
-      "REST API with 10+ endpoints",
-      "Admin dashboard",
-      "Docker deployment on your server",
-      "30-day code warranty",
+      "User authentication (email + social login, password reset, sessions)",
+      "Stripe payments (Checkout + customer portal, subscriptions, webhooks)",
+      "REST API with auth-protected endpoints + OpenAPI docs",
+      "Admin dashboard (user management, content moderation, basic analytics)",
+      "Docker deployment on your server (staging + production)",
+      "CI/CD pipeline + automated backups",
+      "30-day code warranty + handoff walkthrough",
+    ],
+    exclusions: [
+      "Native mobile apps (iOS/Android) — web-responsive only",
+      "Third-party SaaS integrations beyond Stripe (CRM, email tools, etc. quoted separately)",
+      "Post-launch feature additions — captured in a V2 Backlog at fixed price",
+      "Design/branding work beyond system defaults — UI tokens and components included, not custom illustrations",
+      "Ongoing maintenance — see Post-Launch Support ($400/mo) for that",
     ],
     tech: ["Deno", "Preact", "PostgreSQL", "Docker", "Stripe"],
     upworkUrl: UPWORK_URL,
@@ -391,6 +400,24 @@ export default define.page(function Catalog() {
                       </li>
                     ))}
                   </ul>
+                  {item.exclusions && item.exclusions.length > 0 && (
+                    <details class="mt-3">
+                      <summary class="text-gray-500 text-xs cursor-pointer hover:text-gray-400 transition-colors">
+                        Not included
+                      </summary>
+                      <ul class="mt-2 space-y-1.5">
+                        {item.exclusions.map((exc, j) => (
+                          <li
+                            key={j}
+                            class="text-gray-500 text-xs flex items-start gap-2"
+                          >
+                            <span class="text-gray-600 shrink-0">×</span>
+                            {exc}
+                          </li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
                 </details>
 
                 <div class="flex flex-wrap gap-2 mb-5">

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -388,13 +388,35 @@ export default define.page(function Home(ctx) {
               <h3 class="text-lg font-semibold text-white group-hover:text-orange-400 transition-colors mb-2">
                 SaaS MVP
               </h3>
-              <p class="text-gray-400 text-sm mb-3 flex-1 leading-relaxed">
-                Full MVP from idea to live deployment. Auth, payments, API,
-                admin panel. Built to scale.
+              <p class="text-gray-400 text-sm mb-3 leading-relaxed">
+                Full MVP from idea to live deployment.
               </p>
-              <span class="inline-block px-2.5 py-0.5 bg-green-600/40 text-green-300 text-xs font-medium rounded-full mt-auto self-start">
-                From $15,000 — 21 days
-              </span>
+              <ul class="text-xs text-gray-300 space-y-1 mb-3 leading-relaxed">
+                <li class="flex items-start gap-1.5">
+                  <span class="text-green-400 shrink-0">✓</span>
+                  <span>Auth (email + social login)</span>
+                </li>
+                <li class="flex items-start gap-1.5">
+                  <span class="text-green-400 shrink-0">✓</span>
+                  <span>Stripe payments + webhooks</span>
+                </li>
+                <li class="flex items-start gap-1.5">
+                  <span class="text-green-400 shrink-0">✓</span>
+                  <span>REST API + admin dashboard</span>
+                </li>
+                <li class="flex items-start gap-1.5">
+                  <span class="text-green-400 shrink-0">✓</span>
+                  <span>Docker deploy + 30-day warranty</span>
+                </li>
+              </ul>
+              <div class="mt-auto flex items-center justify-between gap-2">
+                <span class="inline-block px-2.5 py-0.5 bg-green-600/40 text-green-300 text-xs font-medium rounded-full self-start">
+                  From $15,000 — 21 days
+                </span>
+                <span class="text-xs text-orange-400 group-hover:text-orange-300 transition-colors font-medium">
+                  Full scope →
+                </span>
+              </div>
             </a>
             <a
               href="/catalog/free-architecture-audit"

--- a/routes/llms-full.txt.ts
+++ b/routes/llms-full.txt.ts
@@ -70,7 +70,7 @@ export const handler = define.handlers({
 - **Catalog:** ${BASE_URL}/catalog — 7 fixed-price offerings
   - /catalog/strategy-call — Strategy Session ($350, 60 min)
   - /catalog/free-architecture-audit — Free Architecture Audit (free, 48h)
-  - /catalog/zero-to-production-saas-mvp — SaaS MVP (from $8K, 21 days)
+  - /catalog/zero-to-production-saas-mvp — SaaS MVP (from $15K, 21 days). Includes auth, Stripe payments, REST API, admin dashboard, Docker deploy, CI/CD, 30-day warranty. Excludes native mobile apps, third-party SaaS integrations, post-launch features.
   - /catalog/bulletproof-backend-api — Backend API (from $4K, 14 days)
   - /catalog/surgical-ai-integration — AI Integration (from $4K, 14 days)
   - /catalog/codebase-health-audit — Code Audit (from $1.5K, 3 days)


### PR DESCRIPTION
Closes [#74](https://github.com/spy4x/antonshubin.com/issues/74)

## Problem

Landing page SaaS MVP card listed only a one-liner ("Auth, payments, API, admin panel. Built to scale."). Budget-conscious founders could not tell what $15K includes and bounced before reaching the catalog page where full scope lives.

## Changes

**`routes/index.tsx` (landing card)**
- Card now shows 4 inline inclusion bullets (auth, Stripe, REST API + admin, Docker + warranty)
- "Full scope →" affordance hints at catalog page (whole card is still clickable)
- Founder can answer "what do I get for $15K" in <10s without clicking

**`routes/catalog/index.tsx`**
- `CatalogItem` gains optional `exclusions: string[]` field
- SaaS MVP item:
  - `includes` enriched from 6 to 7 concrete deliverables (auth details, Stripe specifics, OpenAPI docs, CI/CD, handoff walkthrough)
  - `exclusions` populated with 5 out-of-scope items (mobile apps, integrations, post-launch features, design work, maintenance)
- Index list renders exclusions as nested `<details>` under "What's included"

**`routes/catalog/[slug].tsx` (detail page)**
- New "Not included" section after "What's included"
- Adds upsell footer: "Need something not listed? Most items can be added as a fixed-price milestone"

**`routes/llms-full.txt.ts`**
- Fixes stale "from $8K" → "from $15K" price drift (AI crawlers were quoting wrong price)
- Adds scope summary so AI can answer "what's included" without scraping HTML

**`static/sw.js`**
- Cache version bump v55 → v57 (auto-bumped by deploy script)

## Verification (prod)

- `deno task check` passes (fmt + lint + type-check)
- Local server on :9123 rendered all pages correctly
- **Deployed to production** (antonshubin.com) and re-verified via `curl`:
  - Landing card shows 4-bullet scope + "Full scope →"
  - Catalog detail has separate "Not included" section + upsell footer
  - llms-full.txt has corrected price + scope summary

## Acceptance Criteria (from #74)

- [x] MVP card or linked catalog page shows concrete scope (inclusions + exclusions)
- [x] At least 1 concrete deliverable per category (auth, payments, API, admin, infra)
- [x] Non-technical founder can answer "what do I get for $15K" in <10s

Co-authored-by: openhands <openhands@all-hands.dev>